### PR TITLE
Fix $body ellipsis mismatch + code format

### DIFF
--- a/esterel-rhombus-lib/esterel/full.rhm
+++ b/esterel-rhombus-lib/esterel/full.rhm
@@ -46,14 +46,22 @@ expr.macro
 | 'every ~immediate $s ...:
      $body
      ...':
-    '#{every-immediate/proc}(fun (): $s ..., fun ():
-                                               $body
-                                               ...)'
+    '#{every-immediate/proc}(fun (): $s ..., 
+                             fun ():
+                               $body
+                               ...)'
 | 'every $s ... ~n $n ...:
      $body
      ...':
-    '#{every-n/proc}(fun (): $s ...,$n ...,fun (): $body ...)'
+    '#{every-n/proc}(fun (): $s ...,
+                     $n ...,
+                     fun (): 
+                       $body 
+                       ...)'
 | 'every $s ...:
      $body
      ...':
-    '#{every/proc}(fun (): $s ...,fun (): $body ...)'
+    '#{every/proc}(fun (): $s ...,
+                   fun (): 
+                     $body 
+                     ...)'


### PR DESCRIPTION
In the template, `...` must be in a separate line, if `...` in the pattern is in a separate line (multi group).

Also format the code