### PR TITLE
Bug fixes and updates to the Rhombus bindings

### DIFF
--- a/esterel-rhombus-lib/esterel/full.rhm
+++ b/esterel-rhombus-lib/esterel/full.rhm
@@ -24,7 +24,7 @@ defn.macro 'def_strl $id: $body':
 
 fun
 | sustain(s): full.sustain(s)
-| sustain(s, v): full.sustain(s, v) // this still needs to be tested
+| sustain(s, v): full.sustain(s, v) // so, i can't test if this works because i don't think i can add values to signals
   
 expr.macro
 | 'loop:

--- a/esterel-rhombus-lib/esterel/full.rhm
+++ b/esterel-rhombus-lib/esterel/full.rhm
@@ -17,6 +17,10 @@ export:
   await
   every
   sustain
+  def_strl
+
+defn.macro 'def_strl $id: $body':
+    'def $id: esterel: $body'
 
 fun
 | sustain(s): full.sustain(s)

--- a/esterel-rhombus-lib/esterel/full.rhm
+++ b/esterel-rhombus-lib/esterel/full.rhm
@@ -16,6 +16,11 @@ export:
   loop
   await
   every
+  sustain
+
+fun
+| sustain(s): full.sustain(s)
+| sustain(s, v): full.sustain(s, v) // this still needs to be tested
   
 expr.macro
 | 'loop:

--- a/esterel-rhombus-lib/esterel/full.rhm
+++ b/esterel-rhombus-lib/esterel/full.rhm
@@ -24,7 +24,7 @@ defn.macro 'def_strl $id: $body':
 
 fun
 | sustain(s): full.sustain(s)
-| sustain(s, v): full.sustain(s, v) // so, i can't test if this works because i don't think i can add values to signals
+| sustain(s, v): full.sustain(s, v)
   
 expr.macro
 | 'loop:

--- a/esterel-rhombus-lib/esterel/kernel.rhm
+++ b/esterel-rhombus-lib/esterel/kernel.rhm
@@ -27,15 +27,37 @@ export:
   signal_name
   signal_index
 
-defn.macro
-| 'def_signal {[$id, $combine] , ...}':
-    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
-    'def $id : #{mk-signal/args}(#'$id, #{no-init}, $combine, $srclocs, #false)
-     ...'
-| 'def_signal {$id , ...}':
-    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
-    'def $id : #{mk-signal/args}(#'$id, #{no-init}, #false, $srclocs, #false)
-     ...'
+meta syntax_class SignalDefinition
+| '[$id_expr, ~memoryless, ~init $init_expr, ~combine $combine_expr]':
+    field id = id_expr
+    field init = init_expr
+    field combine = combine_expr
+    field memoryless = #true
+| '[$id_expr, ~init $init_expr, ~combine $combine_expr]':
+    field id = id_expr
+    field init = init_expr
+    field combine = combine_expr
+    field memoryless = #false
+| '[$id_expr, ~combine $combine_expr]':
+    field id = id_expr
+    field init =' #{no-init}'
+    field combine = combine_expr
+    field memoryless = #false
+| '[$id_expr, ~single]':
+    field id = id_expr
+    field init = '#{no-init}'
+    field combine = '#'single'
+    field memoryless = #false
+| '$id_expr':
+    field id = id_expr
+    field init = '#{no-init}'
+    field combine = #false
+    field memoryless = #false
+
+defn.macro 'def_signal {$(signal_definition :: SignalDefinition), ...}':
+  def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}', signal_definition.id]), ...]
+  'def $signal_definition.id : #{mk-signal/args}(#'$signal_definition.id, $signal_definition.init, $signal_definition.combine, $srclocs, $signal_definition.memoryless)
+   ...'
 
 expr.macro 'esterel:
               $body':
@@ -65,22 +87,14 @@ expr.macro 'with_trap $t:
               $body':
   '#{with-trap/proc}(#'$t,fun ($t):
                             $body)'
-
-expr.macro
-| 'with_signal {[$id, $combine] , ...}:
+  
+expr.macro 'with_signal {$(signal_definition :: SignalDefinition), ...}:
               $body':
-    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
-    'block:
-       def $id: #{mk-signal/args}(#'$id, #{no-init}, $combine, $srclocs, #false)
-       ...
-       #{run-and-kill-signals!}([$id,...][0],fun (): $body)'
-| 'with_signal {$id, ...}:
-              $body':
-    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
-    'block:
-       def $id: #{mk-signal/args}(#'$id, #{no-init}, #false, $srclocs, #false)
-       ...
-       #{run-and-kill-signals!}([$id,...][0],fun (): $body)'
+  def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}', signal_definition.id]), ...]
+  'block:
+     def $signal_definition.id : #{mk-signal/args}(#'$signal_definition.id, $signal_definition.init, $signal_definition.combine, $srclocs, $signal_definition.memoryless)
+     ...
+     #{run-and-kill-signals!}([$signal_definition.id,...],fun (): $body)'
 
 expr.macro 'par
             | $body

--- a/esterel-rhombus-lib/esterel/kernel.rhm
+++ b/esterel-rhombus-lib/esterel/kernel.rhm
@@ -22,15 +22,20 @@ export:
   react
   with_trap
   exit_trap
-  with_signals
+  with_signal
   pause
   signal_name
   signal_index
 
-defn.macro 'def_signal: $id ...':
-  def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
-  'def $id : #{mk-signal/args}(#'$id, #{no-init}, #false, $srclocs, #false)
-   ...'
+defn.macro
+| 'def_signal {[$id, $combine] , ...}':
+    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
+    'def $id : #{mk-signal/args}(#'$id, #{no-init}, $combine, $srclocs, #false)
+     ...'
+| 'def_signal {$id , ...}':
+    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
+    'def $id : #{mk-signal/args}(#'$id, #{no-init}, #false, $srclocs, #false)
+     ...'
 
 expr.macro 'esterel:
               $body':
@@ -51,9 +56,9 @@ fun react(r, ~emit: signals = []):
   // the for loop here converts an equal
   // hash into an equal-always hash in
   // order to cooperate better with Rhombus
-  def rkt_signal = PairList(&signals)
+  def rkt_signals = PairList(&signals)
   for Map:
-    each (k,v): kernel.#{react!}(r, ~emit: rkt_signal) :~ Map
+    each (k,v): kernel.#{react!}(r, ~emit: rkt_signals) :~ Map
     values(k,v)
 
 expr.macro 'with_trap $t:
@@ -61,13 +66,21 @@ expr.macro 'with_trap $t:
   '#{with-trap/proc}(#'$t,fun ($t):
                             $body)'
 
-expr.macro 'with_signals {$id, ...}:
+expr.macro
+| 'with_signal {[$id, $combine] , ...}:
               $body':
-  def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
-  'block:
-     def $id: #{mk-signal/args}(#'$id, #{no-init}, #false, $srclocs, #false)
-     ...
-     #{run-and-kill-signals!}([$id,...],fun (): $body)'
+    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
+    'block:
+       def $id: #{mk-signal/args}(#'$id, #{no-init}, $combine, $srclocs, #false)
+       ...
+       #{run-and-kill-signals!}([$id,...][0],fun (): $body)'
+| 'with_signal {$id, ...}:
+              $body':
+    def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
+    'block:
+       def $id: #{mk-signal/args}(#'$id, #{no-init}, #false, $srclocs, #false)
+       ...
+       #{run-and-kill-signals!}([$id,...][0],fun (): $body)'
 
 expr.macro 'par
             | $body
@@ -84,4 +97,4 @@ fun signal_name(s):
   kernel.#{signal-name}(s)
 
 fun signal_index(s):
-  kernel.#{signal-index}(s) // i again can't test this bc `with_signals` doesn't work yet
+  kernel.#{signal-index}(s)

--- a/esterel-rhombus-lib/esterel/kernel.rhm
+++ b/esterel-rhombus-lib/esterel/kernel.rhm
@@ -40,7 +40,7 @@ operator ¿ x:
   #{present?}(x)
 
 expr.macro '$left ||| $right':
-   '#{par/proc}([fun (): $left, fun(): $right])'
+   '#{par/proc}(PairList(fun (): $left, fun(): $right))'
 
 fun
 | emit(s): kernel.emit(s)
@@ -50,8 +50,9 @@ fun react(r, ~emit: signals = []):
   // the for loop here converts an equal
   // hash into an equal-always hash in
   // order to cooperate better with Rhombus
+  def rkt_signal = PairList(&signals)
   for Map:
-    each (k,v): kernel.#{react!}(r, ~emit: signals) :~ Map
+    each (k,v): kernel.#{react!}(r, ~emit: rkt_signal) :~ Map
     values(k,v)
 
 expr.macro 'with_trap $t:
@@ -70,7 +71,7 @@ expr.macro 'with_signals {$id, ...}:
 expr.macro 'par
             | $body
             | ...':
-  '#{par/proc}([fun (): $body, ...])'
+  '#{par/proc}(PairList(&[fun (): $body, ...]))'
 
 expr.macro 'pause':
   'kernel.pause()'

--- a/esterel-rhombus-lib/esterel/kernel.rhm
+++ b/esterel-rhombus-lib/esterel/kernel.rhm
@@ -11,6 +11,7 @@ import:
     expose #{no-init}
   lib("syntax/location.rkt"):
     expose #{quote-srcloc}
+  lib("racket/set.rkt") as rset
 
 export:
   def_signal
@@ -94,7 +95,7 @@ expr.macro 'with_signal {$(signal_definition :: SignalDefinition), ...}:
   'block:
      def $signal_definition.id : #{mk-signal/args}(#'$signal_definition.id, $signal_definition.init, $signal_definition.combine, $srclocs, $signal_definition.memoryless)
      ...
-     #{run-and-kill-signals!}([$signal_definition.id,...],fun (): $body)'
+     #{run-and-kill-signals!}(rset.set($signal_definition.id,...),fun (): $body)'
 
 expr.macro 'par
             | $body

--- a/esterel-rhombus-lib/esterel/kernel.rhm
+++ b/esterel-rhombus-lib/esterel/kernel.rhm
@@ -25,6 +25,7 @@ export:
   with_signals
   pause
   signal_name
+  signal_index
 
 defn.macro 'def_signal: $id ...':
   def [srclocs, ...] = [expr_meta.pack_s_exp(['#{quote-srcloc}',id]), ...]
@@ -81,3 +82,6 @@ fun exit_trap(t):
 
 fun signal_name(s):
   kernel.#{signal-name}(s)
+
+fun signal_index(s):
+  kernel.#{signal-index}(s) // i again can't test this bc `with_signals` doesn't work yet


### PR DESCRIPTION
A few updates and bug fixes to the Rhombus bindings:

1. Fix `react`, `par`, and `|||` in the Rhombus bindings
2. Add `sustain` to the Rhombus bindings
3. Add `def_strl $id: $body` shorthand for `def $id: esterel: $body`
4. Add `signal_index` to the Rhombus bindings
5. Rename `with_signals` -> `with_signal` to be consistent with `def_signal`
6. Change `def_signal: $id...` syntax to `def_signal {$id,...}` to be consistent with `with_signal`
7. Add combine option for `def_signal` and `with_signal`: `def_signal {[$id, $combine], ...}` and `with_signal {[$id, $combine], ...}: $body`