### PR TITLE
Await with cases

### DIFF
--- a/esterel-lib/esterel/private/full.rkt
+++ b/esterel-lib/esterel/private/full.rkt
@@ -6,6 +6,32 @@
          await/proc await-n/proc await-immediate/proc
          every-n/proc every/proc every-immediate/proc)
 
+(struct branch (is-immediate test body))
+
+(begin-for-syntax
+  (struct branch (is-immediate test body))
+
+  (define-splicing-syntax-class maybe-immediate
+    (pattern (~seq #:immediate)
+      #:attr parsed-boolean (syntax #true))
+    (pattern (~seq)
+      #:attr parsed-boolean (syntax #false)))
+
+  (define-syntax-class single-branch
+    (pattern
+      (imm:maybe-immediate
+       test:expr)
+       #:attr parsed-branch #`(branch imm.parsed-boolean
+                                      (λ () test)
+                                      (λ () (void))))
+    (pattern
+      (imm:maybe-immediate
+       test:expr
+       clause:expr)
+       #:attr parsed-branch #`(branch imm.parsed-boolean
+                                      (λ () test)
+                                      (λ () clause)))))
+
 (define (halt)
   (let loop ()
     (pause)
@@ -33,7 +59,9 @@
          #'(await-n/proc (λ () e) n)
          #'(await/proc (λ () e)))]
     [(_ #:immediate e:expr)
-     #'(await-immediate/proc (λ () e))]))
+     #'(await-immediate/proc (λ () e))]
+    [(_ #:cases b:single-branch ...+)
+     #'(await-cases/proc (list b.parsed-branch ...))]))
 
 (define (await/proc thunk)
   (with-trap T-await
@@ -62,6 +90,28 @@
       (when (test-thunk)
         (exit-trap T-await-immediate))
       (pause)
+      (loop))))
+
+(define (handle-immediate-cases T-await-cases branches)
+  (for ([a-branch branches])
+    (when (and (branch-is-immediate a-branch) ((branch-test a-branch)))
+      ((branch-body a-branch))
+      (exit-trap T-await-cases))))
+
+(define (handle-all-cases T-await-cases branches)
+  (for ([a-branch branches])
+    (when ((branch-test a-branch))
+      ((branch-body a-branch))
+      (exit-trap T-await-cases))))
+
+(define (await-cases/proc branches)
+  (with-trap T-await-cases
+    (handle-immediate-cases T-await-cases
+                            branches)
+    (let loop ()
+      (pause)
+      (handle-all-cases T-await-cases
+                        branches)
       (loop))))
 
 (define-syntax (every stx)

--- a/esterel-test/esterel/tests/await-cases.rkt
+++ b/esterel-test/esterel/tests/await-cases.rkt
@@ -1,0 +1,249 @@
+#lang racket/base
+
+(require esterel/full rackunit)
+
+(define-signal A B C x y z)
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [(present? A) (emit x)]
+                              [(present? B)]
+                              [#:immediate (present? C) (emit z)])))
+            (define first-instant-result (react! e))
+            (define second-instant-result (react! e))
+            (define third-instant-result (react! e))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref third-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref third-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref third-instant-result B 'not-in-hash) #f)
+            (check equal? (hash-ref third-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [(present? A) (emit x)]
+                              [(present? B)]
+                              [#:immediate (present? C) (emit z)])))
+            (define first-instant-result (react! e #:emit (list B)))
+            (define second-instant-result (react! e #:emit (list A B C)))
+            (define third-instant-result (react! e))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref third-instant-result C 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [(present? A) (emit x)]
+                              [(present? B)]
+                              [#:immediate (present? C) (emit z)])))
+            (define first-instant-result (react! e #:emit (list B)))
+            (define second-instant-result (react! e #:emit (list B C)))
+            (define third-instant-result (react! e))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref third-instant-result C 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [(present? A) (emit x)]
+                              [(present? B)]
+                              [#:immediate (present? C) (emit z)])))
+            (define first-instant-result (react! e #:emit (list B)))
+            (define second-instant-result (react! e #:emit (list)))
+            (define third-instant-result (react! e #:emit (list B C)))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref third-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref third-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref third-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref third-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [(present? A) (emit x)]
+                              [(present? B)]
+                              [#:immediate (present? C) (emit z)])))
+            (define first-instant-result (react! e #:emit (list C)))
+            (define second-instant-result (react! e #:emit (list)))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) #t)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [#:immediate (present? A) (emit x)]
+                              [(present? B)]
+                              [#:immediate (present? C) (emit z)])))
+            (define first-instant-result (react! e #:emit (list A C)))
+            (define second-instant-result (react! e #:emit (list A B C)))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [(present? A) (emit x)]
+                              [(present? B) (emit y)]
+                              [(present? C) (emit z)])))
+            (define first-instant-result (react! e #:emit (list A B C)))
+            (define second-instant-result (react! e #:emit (list B C)))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) #t)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [#:immediate (present? A) (emit x)]
+                              [(present? B) (emit y)]
+                              [(present? C) (emit z)])))
+            (define first-instant-result (react! e #:emit (list)))
+            (define second-instant-result (react! e #:emit (list)))
+            (define third-instant-result (react! e #:emit (list A C)))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref third-instant-result C 'not-in-hash) #t)
+            (check equal? (hash-ref third-instant-result A 'not-in-hash) #t)
+            (check equal? (hash-ref third-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result x 'not-in-hash) #t)
+            (check equal? (hash-ref third-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result z 'not-in-hash) 'not-in-hash))
+
+(test-begin (define e (esterel
+                       (await #:cases
+                              [(present? A) (emit x)])))
+            (define first-instant-result (react! e #:emit (list A)))
+            (define second-instant-result (react! e #:emit (list)))
+            (define third-instant-result (react! e #:emit (list A)))
+
+            (check equal? (hash-ref first-instant-result C 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result A 'not-in-hash) #t)
+            (check equal? (hash-ref first-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref first-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref second-instant-result C 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result A 'not-in-hash) #f)
+            (check equal? (hash-ref second-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result x 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref second-instant-result z 'not-in-hash) 'not-in-hash)
+
+            (check equal? (hash-ref third-instant-result C 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result A 'not-in-hash) #t)
+            (check equal? (hash-ref third-instant-result B 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result x 'not-in-hash) #t)
+            (check equal? (hash-ref third-instant-result y 'not-in-hash) 'not-in-hash)
+            (check equal? (hash-ref third-instant-result z 'not-in-hash) 'not-in-hash))


### PR DESCRIPTION
Adds the `await case` construct as specified in section 8.11.1 of the [Esterel Reference Manual](https://www.college-de-france.fr/media/gerard-berry/UPL681247605558671166_Esterelv7.60_ReferenceManual.pdf) 

Implementation by @bennettlindberg and @ndh4