### PR TITLE
Add watch to examples

### DIFF
--- a/esterel-examples/esterel/examples/private/create-watch.rkt
+++ b/esterel-examples/esterel/examples/private/create-watch.rkt
@@ -1,0 +1,16 @@
+#lang racket
+
+(require esterel/full)
+
+; IMPORTS
+(require "./watch-signals.rkt")
+(require "./watch-button.rkt")
+(require "./watch-core.rkt")
+(provide create-watch)
+   
+; MAIN
+(define (create-watch)
+  (esterel #:pre 1
+           (par
+            (button)
+            (watch))))

--- a/esterel-examples/esterel/examples/private/watch-button.rkt
+++ b/esterel-examples/esterel/examples/private/watch-button.rkt
@@ -1,0 +1,54 @@
+#lang racket
+
+(require esterel/full)
+
+; IMPORTS & EXPORTS
+(require "./watch-signals.rkt")
+(provide button)
+
+; BRANCHES
+(define view-watch::LR_received
+  (λ () (let loop ()
+          (if (present? LR)
+              (emit TOGGLE_24H_MODE_COMMAND)
+              (void))
+          (pause)
+          (loop))))
+(define set-watch::LL_received
+  (λ () (let loop ()
+          (if (present? LL)
+              (emit NEXT_WATCH_TIME_POSITION_COMMAND)
+              (void))
+          (pause)
+          (loop))))
+(define set-watch::LR_received
+  (λ () (let loop ()
+          (if (present? LR)
+              (emit SET_WATCH_COMMAND)
+              (void))
+          (pause)
+          (loop))))
+
+; MAIN
+(define view-watch
+  (λ ()
+    (abort
+     (par
+      (view-watch::LR_received))
+     #:when (present? UL))
+    (emit ENTER_SET_WATCH_MODE_COMMAND)))
+
+(define set-watch
+  (λ ()
+    (abort
+     (par
+      (set-watch::LL_received)
+      (set-watch::LR_received))
+     #:when (present? UL))
+    (emit EXIT_SET_WATCH_MODE_COMMAND)))
+
+(define button
+  (λ () (let loop ()
+          (view-watch)
+          (set-watch)
+          (loop))))

--- a/esterel-examples/esterel/examples/private/watch-core.rkt
+++ b/esterel-examples/esterel/examples/private/watch-core.rkt
@@ -1,0 +1,111 @@
+#lang racket
+
+(require esterel/full)
+
+; IMPORTS & EXPORTS
+(require "./watch-signals.rkt")
+(provide watch)
+
+(define get-next-watch-time-position
+  (λ (current-position)
+    (cond
+      [(equal? current-position 'hours) 'minutes]
+      [(equal? current-position 'minutes) 'seconds]
+      [(equal? current-position 'seconds) 'hours])))
+
+(define (increment-time cur-time mode)
+  (case mode
+    ('set-hours (set-mode-increment-time cur-time 'hours))
+    ('set-minutes (set-mode-increment-time cur-time 'minutes))
+    ('set-seconds (set-mode-increment-time cur-time 'seconds))
+    ('view (view-mode-increment-time cur-time))
+    (else (raise-argument-error 'increment-time "'set-hour, 'set-minute, 'set-second, or 'view" mode))))
+
+(define (view-mode-increment-time cur-time)
+  (if (= 59 (time-seconds cur-time))
+      (if (= 59 (time-minutes cur-time))
+          (if (= 23 (time-hours cur-time))
+              (time 0 0 0)
+              (time (+ 1 (time-hours cur-time)) 0 0))
+          (time (time-hours cur-time) (+ 1 (time-minutes cur-time)) 0))
+      (time (time-hours cur-time) (time-minutes cur-time) (+ 1 (time-seconds cur-time)))))
+
+(define (set-mode-increment-time cur-time position)
+  (case position
+    ('seconds cur-time)
+    ('minutes (time (time-hours cur-time) (time-minutes cur-time) (modulo (+ 1 (time-seconds cur-time)) 60)))
+    ('hours (if (= 59 (time-seconds cur-time))
+                (time (time-hours cur-time) (modulo (+ 1 (time-minutes cur-time)) 60) 0)
+                (time (time-hours cur-time) (time-minutes cur-time) (+ 1 (time-seconds cur-time)))))))
+
+(define (get-mode-from-watch-position position)
+  (case position
+    ('hours 'set-hours)
+    ('minutes 'set-minutes)
+    ('seconds 'set-seconds)
+    (else (raise-argument-error 'get-mode-from-watch-position "'hours, 'minutes, or 'seconds" position))))
+
+(define (increment-position cur-time position)
+  (case position
+    ('hours (time (modulo (+ 1 (time-hours cur-time)) 24) (time-minutes cur-time) (time-seconds cur-time)))
+    ('minutes (time (time-hours cur-time) (modulo (+ 1 (time-minutes cur-time)) 60) (time-seconds cur-time)))
+    ('seconds (time (time-hours cur-time) (time-minutes cur-time) (modulo (+ 1 (time-seconds cur-time)) 60)))))
+
+(define (repeat signal can)
+  (emit signal (signal-value signal #:pre 1 #:can can)))
+
+; LISTENERS
+(define view-watch
+  (λ ()
+    (with-trap EXIT_VIEW_MODE
+      (let loop ()
+        (await #:cases
+               [#:immediate (and (present? ENTER_SET_WATCH_MODE_COMMAND) (not (present? EXIT_SET_WATCH_MODE_COMMAND)))
+                (exit-trap EXIT_VIEW_MODE)]
+               [#:immediate (present? S)
+                (begin (repeat 24H_MODE (set))
+                       (emit WATCH_TIME (increment-time (signal-value WATCH_TIME #:pre 1 #:can (set)) 'view)))]
+               [#:immediate (present? TOGGLE_24H_MODE_COMMAND)
+                (begin (emit 24H_MODE (not (signal-value 24H_MODE #:pre 1 #:can (set))))
+                       (repeat WATCH_TIME (set)))]
+               [#:immediate #t
+                (begin (repeat WATCH_TIME (set))
+                       (repeat 24H_MODE (set)))])
+        (pause)
+        (loop)))))
+
+(define set-watch
+  (λ ()
+    (with-trap EXIT_SET_MODE
+      (emit WATCH_TIME_POSITION 'hours)
+      (let loop ()
+        (await #:cases
+               [#:immediate (and (present? EXIT_SET_WATCH_MODE_COMMAND) (not (present? ENTER_SET_WATCH_MODE_COMMAND)))
+                (exit-trap EXIT_SET_MODE)]
+               [#:immediate (present? S)
+                (begin (emit WATCH_TIME (increment-time (signal-value WATCH_TIME #:pre 1 #:can (set))
+                                                        (get-mode-from-watch-position (signal-value WATCH_TIME_POSITION #:pre 1 #:can (set)))))
+                       (repeat WATCH_TIME_POSITION (set))
+                       (repeat 24H_MODE (set)))]
+               [#:immediate (present? SET_WATCH_COMMAND)
+                (begin (emit WATCH_TIME (increment-position (signal-value WATCH_TIME #:pre 1 #:can (set))
+                                                            (signal-value WATCH_TIME_POSITION #:pre 1 #:can (set))))
+                       (repeat WATCH_TIME_POSITION (set))
+                       (repeat 24H_MODE (set)))]
+               [#:immediate (present? NEXT_WATCH_TIME_POSITION_COMMAND)
+                (begin (emit WATCH_TIME_POSITION (get-next-watch-time-position (signal-value WATCH_TIME_POSITION #:pre 1 #:can (set))))
+                       (repeat WATCH_TIME (set))
+                       (repeat 24H_MODE (set)))]
+               [#:immediate #t
+                (begin (repeat WATCH_TIME_POSITION (set))
+                       (repeat WATCH_TIME (set))
+                       (repeat 24H_MODE (set)))])
+        (pause)
+        (loop)))))
+
+; MAIN
+(define watch
+  (λ () (let loop ()
+          (view-watch)
+          (set-watch)
+          (loop))))

--- a/esterel-examples/esterel/examples/private/watch-signals.rkt
+++ b/esterel-examples/esterel/examples/private/watch-signals.rkt
@@ -1,0 +1,31 @@
+#lang racket
+
+(require esterel/full)
+
+; EXPORTS
+(provide (all-defined-out))
+
+; INPUTS
+(define-signal S)
+(define-signal LL LR UL UR)
+
+; VIEW WATCH
+(struct time (hours minutes seconds) #:transparent)
+(define-signal WATCH_TIME #:init (time 0 0 0) #:combine (λ (a b) a))
+;(define-signal INCREMENT_WATCH_TIME)
+(define-signal 24H_MODE #:init #f #:combine (λ (a b) (and a b)))
+(define-signal TOGGLE_24H_MODE_COMMAND)
+
+; SET WATCH
+(define-signal WATCH_TIME_POSITION #:init 'hours #:combine (λ (a b) a))
+;(define-signal INCREMENT_WATCH_POSITION)
+(define-signal ENTER_SET_WATCH_MODE_COMMAND)
+(define-signal EXIT_SET_WATCH_MODE_COMMAND)
+(define-signal SET_WATCH_COMMAND)
+(define-signal NEXT_WATCH_TIME_POSITION_COMMAND)
+
+; STOPWATCH
+
+; VIEW ALARM
+
+; SET ALARM

--- a/esterel-examples/esterel/examples/watch.rkt
+++ b/esterel-examples/esterel/examples/watch.rkt
@@ -1,0 +1,283 @@
+#lang racket/base
+
+; IMPORTS & EXPORTS
+(require racket/gui/base
+         racket/class
+         racket/pretty)
+(require esterel/full)
+(require "./private/watch-signals.rkt")
+(require "./private/create-watch.rkt")
+
+(define watch (create-watch))
+
+(define (to-2digit-string num)
+  (define as-string (format "~s" num))
+  (if (< (string-length as-string) 2)
+      (string-append "0" as-string)
+      as-string))
+
+(define (update-gui hash)
+
+  (define time (hash-ref hash WATCH_TIME))
+
+  (send hh set-label
+        (to-2digit-string
+         (if (hash-ref hash 24H_MODE)
+             (time-hours time)
+             (let ([modded (modulo (time-hours time) 12)])
+               (if (= 0 modded)
+                   12
+                   modded)))))
+
+  (send mm set-label
+        (to-2digit-string (time-minutes time)))
+  
+  (send seconds-display set-label
+        (to-2digit-string (time-seconds time)))
+
+  (if (hash-ref hash 24H_MODE)
+            (begin (send twenty4h-display set-label "24h")
+                   (send ampm-display set-label ""))
+            (begin (send twenty4h-display set-label "")
+                   (send ampm-display set-label
+                         (if (>= (time-hours time) 12)
+                "PM"
+                "AM"))))
+
+  (define emphasis-color
+    (make-object color% 255 0 0))
+
+  (define normal-color
+    (make-object color% 0 0 0))
+
+  (case (hash-ref hash WATCH_TIME_POSITION #false)
+    [(hours) (send hh set-color emphasis-color)
+             (send mm set-color normal-color)
+             (send seconds-display set-color normal-color)]
+    [(minutes) (send mm set-color emphasis-color)
+               (send hh set-color normal-color)
+               (send seconds-display set-color normal-color)]
+    [(seconds) (send seconds-display set-color emphasis-color)
+               (send hh set-color normal-color)
+               (send mm set-color normal-color)]
+    [else
+     (send hh set-color normal-color)
+     (send mm set-color normal-color)
+     (send seconds-display set-color normal-color)])
+  )
+
+
+;; Font configurations
+
+(define hhmm-font
+  (make-object font% 70 'modern 'normal 'bold))
+
+(define seconds-font
+  (make-object font% 50 'modern 'normal 'bold))
+
+(define twenty4h-font
+  (make-object font% 25 'modern 'normal 'bold))
+
+(define ampm-font
+  (make-object font% 25 'modern 'normal 'bold))
+
+;; GUI Elements
+
+(define frame (new frame% [label "Watch"]))
+
+(define entire-space
+  (new horizontal-panel%
+       [parent frame]))
+
+#;(define test-message
+  (new message%
+       [parent entire-space]
+       [label "hello wordl"]))
+
+;; entire-space children
+
+(define left-buttons
+  (new vertical-panel%
+       [parent entire-space]))
+
+(define display-with-padding
+  (new panel%
+       [parent entire-space]
+       [style '(border)]))
+
+(define right-buttons
+  (new vertical-panel%
+       [parent entire-space]))
+
+;; left-buttons children
+
+(define UL-button
+  (new button%
+     [parent left-buttons]
+     [label "UL"]
+     [callback (λ (button event)
+                 (update-gui (react! watch #:emit (list UL))))]))
+
+(define left-buttons-spacer
+  (new vertical-panel%
+       [parent left-buttons]
+       [min-height 10]))
+
+(define LL-button
+  (new button%
+     [parent left-buttons]
+     [label "LL"]
+     [callback (λ (button event)
+                 (update-gui (react! watch #:emit (list LL))))]))
+
+;; display-with-padding children
+
+(define rectangular-display
+  (new vertical-panel%
+       [parent display-with-padding]
+       [min-height 100]
+       [min-width  500]
+       [vert-margin  10]
+       [horiz-margin 10]
+       [style '(border)]))
+
+;; right-buttons children
+
+(define UR-button
+  (new button%
+     [parent right-buttons]
+     [label "UR"]
+     [callback (λ (button event)
+                 (update-gui (react! watch #:emit (list UR))))]))
+
+(define right-buttons-spacer
+  (new vertical-panel%
+       [parent right-buttons]
+       [min-height 10]))
+
+(define LR-button
+  (new button%
+     [parent right-buttons]
+     [label "LR"]
+     [callback (λ (button event)
+                 (update-gui (react! watch #:emit (list LR))))]))
+
+;; rectangular-display children
+
+(define top-third
+  (new horizontal-panel%
+       [parent rectangular-display]))
+
+(define middle-third
+  (new horizontal-panel%
+       [parent rectangular-display]))
+
+(define bottom-third
+  (new horizontal-panel%
+       [parent rectangular-display]))
+
+;; middle-third children
+
+(define ampm24h
+  (new vertical-panel%
+       [parent middle-third]
+       [style '(border)]))
+
+(define m3spacer
+  (new panel%
+       [parent middle-third]
+       [min-width 35]
+       [style '(border)]))
+
+;; bottom-third children
+
+
+(define hhmm-container
+  (new horizontal-panel%
+       [parent bottom-third]
+       [min-width 300]
+       [alignment '(center center)]
+       [style '(border)]))
+
+(define ss-container
+  (new horizontal-panel%
+       [parent bottom-third]
+       [min-width 200]
+       [alignment '(center center)]
+       [style '(border)]))
+
+;; hhmm-container children
+
+(define hh
+  (new message%
+       [parent hhmm-container]
+       [auto-resize #t]
+       [font hhmm-font]
+       [label "12"]))
+
+(define colon
+  (new message%
+       [parent hhmm-container]
+       [auto-resize #t]
+       [font hhmm-font]
+       [label ":"]))
+
+(define mm
+  (new message%
+       [parent hhmm-container]
+       [auto-resize #t]
+       [font hhmm-font]
+       [label "00"]))
+
+;; ss-container children
+
+(define seconds-display
+  (new message%
+       [parent ss-container]
+       [font seconds-font]
+       [auto-resize #t]
+       [label "00"]))
+
+;; ampm24h children
+
+(define ampm-display
+  (new message%
+       [parent ampm24h]
+       [min-height 10]
+       [min-width 30]
+       [vert-margin 10]
+       [auto-resize #t]
+       [font ampm-font]
+       [label "AM"]))
+
+(define twenty4h-display
+  (new message%
+       [parent ampm24h]
+       [min-height 10]
+       [min-width 30]
+       [vert-margin 10]
+       [auto-resize #t]
+       [font twenty4h-font]
+       [label ""]))
+
+(define manual-quartz
+  (new button%
+     [parent frame]
+     [label "S"]
+     [callback (λ (button event)
+                 (update-gui (react! watch #:emit (list S))))]))
+
+(define quartz-timer
+  (new timer%
+     [notify-callback (λ ()
+                        (update-gui
+                         (react! watch #:emit (list S))))]))
+
+(define toggle-autoquartz
+  (new button%
+     [parent frame]
+     [label "Enter real(ish)time mode"]
+     [callback (λ (button event)
+                 (send quartz-timer start 883))]))
+
+(send frame show #t)


### PR DESCRIPTION
Implements the watch specified in Gérard Berry's "Programming a digital watch in Esterel v3", minus the Stopwatch and Alarm functionality. The GUI and quartz are implemented in `watch.rkt`, while the logic of the watch itself lies in the files added to the `private` directory.

Authored by @bennettlindberg and @ndh4