### PR TITLE
Update Rhombus dependency

### DIFF
--- a/esterel-examples/info.rkt
+++ b/esterel-examples/info.rkt
@@ -4,7 +4,7 @@
 
 (define deps '("base"
                "esterel-lib"
-               "esterel-rhombus-lib" "rhombus-prototype"
+               "esterel-rhombus-lib" "rhombus-lib"
                "rackunit" "gui-lib" "pict-lib"))
 
 (define pkg-desc "Some Esterel examples")

--- a/esterel-rhombus-lib/info.rkt
+++ b/esterel-rhombus-lib/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection 'multi)
 
-(define deps '("base" "rhombus-prototype" "esterel-lib"))
+(define deps '("base" "rhombus-lib" "esterel-lib"))
 
 (define pkg-desc "Esterel implementation in Rhombus")
 


### PR DESCRIPTION
The Rhombus packages have been named racket/rhombus@2fbae97.